### PR TITLE
Make Link to www.csmotorclub.com explicit

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,3 @@
 Static CS Motor Club site (sucked out of a stripped-down Wordpress).
 
-Live at [www.csmotorclub.com](www.csmotorclub.com).
+Live at [www.csmotorclub.com](http://www.csmotorclub.com).


### PR DESCRIPTION
right now it is being rendered on https://github.com/willmeyer/www.csmotorclub.com)  https://github.com/willmeyer/www.csmotorclub.com/blob/master/www.csmotorclub.com